### PR TITLE
Add lightweight RL pricing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ After models are trained, call
 "bash test.sh [small/large] [full/ablation]"
 
 The inputs of the NYC scenario can be found at https://drive.google.com/drive/folders/1IVQUZXHgDQMe1IrVX2A60bidymF0Ccbq?usp=share_link.
+\n## Simplified pricing example\nTo quickly experiment with RL methods, run `python simple_train.py --algo TD3 --timesteps 10000`.\nAlgorithms TD3, PPO and SAC from Stable-Baselines3 are supported.

--- a/simple_env.py
+++ b/simple_env.py
@@ -1,0 +1,48 @@
+import gymnasium as gym
+from gymnasium import spaces
+import numpy as np
+
+class PricingEnv(gym.Env):
+    """A lightweight ride-hailing pricing environment."""
+    metadata = {"render_modes": ["human"]}
+
+    def __init__(self, max_steps=200, base_demand=10, vehicles=10,
+                 base_price=1.0, cost_per_ride=0.5):
+        super().__init__()
+        self.max_steps = max_steps
+        self.base_demand = base_demand
+        self.vehicles = vehicles
+        self.base_price = base_price
+        self.cost_per_ride = cost_per_ride
+
+        self.action_space = spaces.Box(low=0.5, high=2.0, shape=(1,), dtype=np.float32)
+        self.observation_space = spaces.Box(low=0.0, high=np.inf, shape=(2,), dtype=np.float32)
+        self.seed()
+        self.reset()
+
+    def seed(self, seed=None):
+        self.np_random, _ = gym.utils.seeding.np_random(seed)
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+        self.step_count = 0
+        self.demand = self.np_random.poisson(self.base_demand)
+        obs = np.array([self.vehicles, self.demand], dtype=np.float32)
+        return obs, {}
+
+    def step(self, action):
+        price_mult = float(np.clip(action[0], self.action_space.low, self.action_space.high))
+        served = min(self.demand, self.vehicles)
+        revenue = served * price_mult * self.base_price
+        cost = served * self.cost_per_ride
+        reward = revenue - cost
+        self.step_count += 1
+
+        self.demand = self.np_random.poisson(self.base_demand / price_mult)
+        obs = np.array([self.vehicles, self.demand], dtype=np.float32)
+        done = self.step_count >= self.max_steps
+        info = {}
+        return obs, reward, done, False, info
+
+    def render(self, mode="human"):
+        print(f"Step: {self.step_count}, demand: {self.demand}")

--- a/simple_train.py
+++ b/simple_train.py
@@ -1,0 +1,41 @@
+import argparse
+import numpy as np
+from simple_env import PricingEnv
+from stable_baselines3 import TD3, PPO, SAC
+from stable_baselines3.common.noise import NormalActionNoise
+
+
+def make_model(algo, env):
+    if algo == "TD3":
+        n_actions = env.action_space.shape[-1]
+        noise = NormalActionNoise(mean=np.zeros(n_actions), sigma=0.1 * np.ones(n_actions))
+        return TD3("MlpPolicy", env, action_noise=noise, verbose=1)
+    if algo == "PPO":
+        return PPO("MlpPolicy", env, verbose=1)
+    if algo == "SAC":
+        return SAC("MlpPolicy", env, verbose=1)
+    raise ValueError(f"Unknown algo {algo}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algo", choices=["TD3", "PPO", "SAC"], default="TD3")
+    parser.add_argument("--timesteps", type=int, default=10000)
+    args = parser.parse_args()
+
+    env = PricingEnv()
+    model = make_model(args.algo, env)
+    model.learn(total_timesteps=args.timesteps)
+    model.save(f"{args.algo}_pricing")
+
+    obs, _ = env.reset()
+    for _ in range(5):
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, done, _, _ = env.step(action)
+        print(f"action {action[0]:.2f}, reward {reward:.2f}")
+        if done:
+            obs, _ = env.reset()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `simple_env.py` implementing a tiny environment for ride-hailing pricing
- add `simple_train.py` that trains TD3, PPO, or SAC using Stable-Baselines3
- update README with instructions for running the simplified example

## Testing
- `python -m py_compile simple_env.py simple_train.py`
- `python simple_train.py --algo TD3 --timesteps 10`

------
https://chatgpt.com/codex/tasks/task_e_6846670e514c833394eee548fa737a14